### PR TITLE
Version4

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -87,10 +87,15 @@ class Crawler {
 
     logger(['registry'.green, this.registryHits], `retrieving ${outputPrefix}${name.cyan} ${(version || '').cyan}`);
     this.registryHits++;
-    const allPackageVersionsDetails = await this._retryGetRequest(uri, 3);
-    this.packagesCache.set(name, allPackageVersionsDetails);
-    const maxSatisfyingVersion = this._getMaxSatisfyingVersion(allPackageVersionsDetails, version);
-    return allPackageVersionsDetails.versions[maxSatisfyingVersion];
+    try {
+      const allPackageVersionsDetails = await this._retryGetRequest(uri, 3);
+      this.packagesCache.set(name, allPackageVersionsDetails);
+      const maxSatisfyingVersion = this._getMaxSatisfyingVersion(allPackageVersionsDetails, version);
+      return allPackageVersionsDetails.versions[maxSatisfyingVersion];
+    } catch (error) {
+      logger([`failed download ${error.cause.code}`.red], uri);
+      throw error;
+    }
   }
 
   async _getDependenciesFrom(dependenciesObject, outputPrefix) {
@@ -114,7 +119,6 @@ class Crawler {
     try {
       return await request({ uri, json: true, timeout: 3000 });
     } catch (error) {
-      logger([`failed download ${error.cause.code}`.red], uri, count);
       if (error.cause.code === 'ETIMEDOUT' || error.cause.code === 'ESOCKETTIMEDOUT') {
         return this._retryGetRequest(uri, count);
       }

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -42,13 +42,31 @@ function _downloadTarballs(tarballs, baseDirectory = './tarballs') {
   }
 
   logger(['downloading tarballs'.bgGreen], { count: tarballs.length });
-  const promises = tarballs.map(({ url, directory }, i, arr) => {
+  const success = new Set();
+  const failed = new Set();
+  const totalCount = tarballs.length;
+
+  const promises = tarballs.map(async ({ url, directory }, i, arr) => {
     const position = `${i + 1}/${arr.length}`;
     logger(['downloading'.cyan, position], url);
 
-    return _downloadFileWithRetry(url, join(baseDirectory, directory), position, 10);
+    const path = join(baseDirectory, directory);
+    try {
+      const duration = await _downloadFileWithRetry(url, path, position, 10);
+      success.add(url);
+      logger(['downloaded tgz'.green, position], url, `${duration}ms`.gray);
+    }
+    catch (error) {
+      logger(['failed download tgz'.red], error.message, url);
+      failed.add(url)
+    }
   });
-  return Promise.all(promises);  
+  return Promise.all(promises).then(() => {
+    logger(['downloaded tgz'.green], `Attempted to download ${totalCount} tarballs, ${success.size} succeeded, ${failed.size} failed`)
+    failed.forEach((value) => {
+      logger(['failed package'.red], value);
+    })
+  });
 }
 async function _downloadFileWithRetry(url, directory, position, count) {
   try {
@@ -56,11 +74,14 @@ async function _downloadFileWithRetry(url, directory, position, count) {
     if (!existsSync(path)) {
       throw new Error(`tgz does not exist ${path}`);
     }
-    if (_validateTarball(path)) logger(['downloaded tgz'.green, position], url, `${duration}ms`.gray);
-    else throw new Error('Error downloading tgz, retrying.. ');
+    if (!_validateTarball(path)) {
+      throw new Error('Error downloading tgz, retrying.. ');
+    }
+    return duration;
   } catch (error) {
-    logger(['failed download tgz'.red], error.message, url, count);
-    if (count > 0) _downloadFileWithRetry(url, directory, position, count - 1);
+    if (count > 0) {
+      _downloadFileWithRetry(url, directory, position, count - 1);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
   },
   "devDependencies": {
     "@types/jasmine": "^2.8.9",
+    "@types/mkdirp": "^0.5.2",
+    "@types/request": "^2.48.1",
+    "@types/request-promise": "^4.1.42",
+    "@types/rimraf": "^2.0.2",
+    "@types/semver": "^5.5.0",
+    "@types/tar": "^4.0.0",
     "jasmine": "^3.2.0",
     "jasmine-console-reporter": "^3.1.0",
     "rimraf": "^2.6.2"


### PR DESCRIPTION
Modified logs to make it easier to follow failures. 
It will report if any package failed to be downloaded at the end, and how many have succeeded. 
Plus, failure logs will not pollute the log (only written if all retries failed)