### PR TITLE
support multi pack: tgz-downloader package express@4.2 colors

### DIFF
--- a/bin/download-tgz
+++ b/bin/download-tgz
@@ -24,12 +24,12 @@ program
     .action((uri, command) => commands.packageLockCommand(uri, command));
 
 program
-    .command('package <name> [version]')
+    .command('package [packages...]')
     .description('download tarballs based on a package and a version')
     .option('--directory [directory]')
     .option('--devDependencies')
     .option('--peerDependencies')
-    .action((name, version, command) => commands.packageCommand(name, version, command));
+    .action((packages, command) => commands.packageCommand(packages, command));
 
 program
     .command('package-json <uri>')

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -14,18 +14,37 @@ async function packageLockCommand(uri, options = {}) {
   downloader.downloadFromPackageLock(packageLock, options.directory);
 }
 
+
+function formatPackageStringIntoMap(packageStr) {
+  let splitted = packageStr.split("@");
+  let formatted = {name: splitted[0]};
+  if(splitted.length > 1) {
+      formatted.version = splitted[1];
+  }
+  return formatted;
+}
+
+
 /**
- * @param {string} name
- * @param {string} version
+ * @param {{name: string, version: ?string}} package
  * @param {{ directory: string, devDependencies: boolean, peerDependencies: boolean }} options
  */
-async function packageCommand(name, version, options = {}) {
-  const tarballsSet = await crawler.getDependencies({
-    name,
-    version,
-    devDependencies: options.devDependencies,
-    peerDependencies: options.peerDependencies,
-  });
+async function packageCommand(packages, options = {}) {
+  let tarballsSet = new Set();
+  if(!Array.isArray(packages))
+  {
+    packages = [packages];
+  }
+  packages = packages.map(formatPackageStringIntoMap);
+  for(let curPackage of packages) {
+    let {name, version} = curPackage;
+    tarballsSet = new Set([...tarballsSet, ...await crawler.getDependencies({
+      name,
+      version,
+      devDependencies: options.devDependencies,
+      peerDependencies: options.peerDependencies,
+    })]);
+  }
   downloader.downloadFromIterable(tarballsSet, options.directory);
 }
 

--- a/test/commands.spec.js
+++ b/test/commands.spec.js
@@ -121,7 +121,15 @@ describe('the (package) command', () => {
     });
 
     it('should work for a simple package', async () => {
-        await commands.packageCommand('express', '4.16.4', {
+        await commands.packageCommand("express@4.16.4", {
+            directory: tarballsDirectory
+        });
+        expect(fs.existsSync(path.join(tarballsDirectory), 'express')).toBeTruthy();
+        expect(fs.existsSync(path.join(tarballsDirectory), 'express', 'express-4.16.4.tgz')).toBeTruthy();
+    });
+
+    it('should work for a package array', async () => {
+        await commands.packageCommand(['express@4.16.4', 'colors'], {
             directory: tarballsDirectory
         });
         expect(fs.existsSync(path.join(tarballsDirectory), 'express')).toBeTruthy();
@@ -129,7 +137,7 @@ describe('the (package) command', () => {
     });
 
     it('should work for the current package', async () => {
-        await commands.packageCommand('node-tgz-downloader', undefined, {
+        await commands.packageCommand('node-tgz-downloader', {
             directory: tarballsDirectory
         });
         const paths = [


### PR DESCRIPTION
**What is this**
This PR adds support to downloading multiple packages using this command:
`node-tgz-downloader package express@4.16.4 colors@1.3.3 react`

(you don't have to declare a version, you can remove the @ and leave the version empty to let it choose the last version)

**Why**
now tgz-downloader supports only this format:
`node-tgz-downloader package express 4.16.4`

and when you want to download more than one package without package.json it can be annoying.
you'll have to wait each one of them, go to drink or eat something while it downloads, download another one.. eat another sandwich.. and back halila.

**NOTE:**
It will deprecate the previous use for declining version. I can use a different command called "packages" instead of "package" 
if it is a problem.
I think this way is better anyway, cause it's the way the original "npm install" and "yarn add" work.
with this @ thing