### PR TITLE
并发控制(Concurrency control)

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -2,6 +2,7 @@ const request = require('request-promise');
 const semver = require('semver');
 const util = require('util');
 const logger = require('./logger');
+const PromiseLimit = require('./limit')
 
 require('colors');
 
@@ -96,7 +97,7 @@ class Crawler {
 
   async _getDependenciesFrom(dependenciesObject, outputPrefix) {
     const dependencies = Object.keys(dependenciesObject || {});
-    await Promise.all(dependencies.map(dependency => this.getDependencies({
+    await PromiseLimit(dependencies.map(dependency => ()=> this.getDependencies({
       name: dependency,
       version: dependenciesObject[dependency],
       outputPrefix,
@@ -128,5 +129,5 @@ class Crawler {
 }
 
 module.exports = {
-  Crawler 
+  Crawler
 };

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -6,11 +6,12 @@ const tar = require('tar');
 const logger = require('./logger');
 const downloadFileAsync = require('./download-file');
 const urlResolver = require('./url-resolver');
+const PromiseLimit = require('./limit')
 
 require('colors');
 
 /**
- * @param {{directory: string, registry?: string}} options 
+ * @param {{directory: string, registry?: string}} options
  */
 function downloadFromPackageLock(packageLock, options) {
   const tarballs = [];
@@ -21,7 +22,7 @@ function downloadFromPackageLock(packageLock, options) {
 
 /**
  * @param { Iterable<string> | ArrayLike<string> } tarballsIterable
- * @param {{directory: string, registry?: string}} options 
+ * @param {{directory: string, registry?: string}} options
  */
 function downloadFromIterable(tarballsIterable, options) {
   const tarballs = Array.from(tarballsIterable)
@@ -30,7 +31,7 @@ function downloadFromIterable(tarballsIterable, options) {
 }
 
 /**
- * @param {{directory: string, registry?: string}} options 
+ * @param {{directory: string, registry?: string}} options
  */
 function _enumerateDependencies(tarballs, dependencies, options) {
   for (const [dependencyName, dependency] of Object.entries(dependencies)) {
@@ -53,9 +54,9 @@ function _downloadTarballs(tarballs, baseDirectory = './tarballs') {
     const position = `${i + 1}/${arr.length}`;
     logger(['downloading'.cyan, position], url);
 
-    return _downloadFileWithRetry(url, join(baseDirectory, directory), position, 10);
+    return ()=> _downloadFileWithRetry(url, join(baseDirectory, directory), position, 10);
   });
-  return Promise.all(promises);  
+  return PromiseLimit(promises);
 }
 async function _downloadFileWithRetry(url, directory, position, count) {
   try {

--- a/lib/limit.js
+++ b/lib/limit.js
@@ -1,5 +1,4 @@
-module.exports = function PromiseLimit(funcArray, limit = 5) {
-
+function PromiseLimit(funcArray, limit = 5) {
     let i = 0;
     const result = [];
     const executing = [];
@@ -10,7 +9,6 @@ module.exports = function PromiseLimit(funcArray, limit = 5) {
         const e = p.then(() => executing.splice(executing.indexOf(e), 1));
         executing.push(e);
         if (executing.length >= limit) {
-
             return Promise.race(executing).then(
                 () => queue(),
                 e => Promise.reject(e)
@@ -19,4 +17,8 @@ module.exports = function PromiseLimit(funcArray, limit = 5) {
         return Promise.resolve().then(() => queue());
     };
     return queue().then(() => Promise.all(result));
+}
+
+module.exports = {
+    PromiseLimit
 }

--- a/lib/limit.js
+++ b/lib/limit.js
@@ -26,6 +26,4 @@ function PromiseLimit(funcArray, limit = 5) {
     return queue().then(() => Promise.all(result));
 }
 
-module.exports = {
-    PromiseLimit
-}
+module.exports = PromiseLimit

--- a/lib/limit.js
+++ b/lib/limit.js
@@ -1,0 +1,22 @@
+module.exports = function PromiseLimit(funcArray, limit = 5) {
+
+    let i = 0;
+    const result = [];
+    const executing = [];
+    const queue = function () {
+        if (i === funcArray.length) return Promise.all(executing);
+        const p = funcArray[i++]();
+        result.push(p);
+        const e = p.then(() => executing.splice(executing.indexOf(e), 1));
+        executing.push(e);
+        if (executing.length >= limit) {
+
+            return Promise.race(executing).then(
+                () => queue(),
+                e => Promise.reject(e)
+            );
+        }
+        return Promise.resolve().then(() => queue());
+    };
+    return queue().then(() => Promise.all(result));
+}

--- a/lib/limit.js
+++ b/lib/limit.js
@@ -1,3 +1,10 @@
+/**
+ * [ Promise.all ] Concurrency control
+ * @param funcArray function array
+ * @param limit max concurrency
+ * @returns {Promise<any[]>}
+ * @constructor
+ */
 function PromiseLimit(funcArray, limit = 5) {
     let i = 0;
     const result = [];


### PR DESCRIPTION
由于Promise.all没有并发限制，导致请求过多(成千上万)，依赖过多时或网络状况不佳时会导致下载失败。
修改默认限制为5个并发。

> Because Promise.all has no concurrency limit, it leads to too many requests (thousands). If there is too much dependency or the network condition is not good, the download will fail.
> Modify the default limit to 5 concurrent.